### PR TITLE
chore(deps): mega PR combining open renovate update PRs

### DIFF
--- a/.github/workflows/container-build.yaml
+++ b/.github/workflows/container-build.yaml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v3.6.0
+        uses: docker/login-action@v4.2.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -37,12 +37,12 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v5.10.0
+        uses: docker/metadata-action@v6.1.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v6.18.0
+        uses: docker/build-push-action@v7.2.0
         with:
           context: .
           push: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.14.0-alpine
+FROM python:3.14.6-alpine
 # hadolint ignore=DL3018
 RUN apk add --update --no-cache bash ca-certificates curl git jq openssh
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 pyyaml==6.0.3
-wheel==0.45.1
-yamllint==1.37.1
+wheel==0.47.0
+yamllint==1.38.0


### PR DESCRIPTION
Combines all currently open Renovate dependency-update PRs into a single PR so CI can validate them together. All open PRs in this repo are Renovate-authored — no contributor PRs to exclude.

## Included (superseded — can be closed once this merges)
- #63 chore(deps): update docker/build-push-action action to v7
- #62 chore(deps): update docker/login-action action to v4
- #61 chore(deps): update docker/metadata-action action to v6
- #58 chore(deps): update python docker tag to v3.14
- #57 chore(deps): update wheel to 0.47.0
- #56 chore(deps): update yamllint to 1.38.0

## Redundant once this merges (minor bumps subsumed by the major bumps above — same line, lower version)
- #60 chore(deps): update docker/build-push-action action to v6.19.2 (superseded by #63's v7.2.0)
- #59 chore(deps): update docker/login-action action to v3.7.0 (superseded by #62's v4.2.0)

## Verification
- `.github/workflows/container-build.yaml` triggers on `pull_request` to `main`, so GitHub Actions will run automatically against this PR to confirm the container build is not broken.

---
_Generated by [Claude Code](https://claude.ai/code/session_01M4M9o6saae5zGmzEzZGrCb)_